### PR TITLE
allow custom error message for failed validation

### DIFF
--- a/tasks/filenames.js
+++ b/tasks/filenames.js
@@ -47,7 +47,11 @@ module.exports = function(grunt) {
         grunt.verbose.writeln('testing filename', filename);
         var valid = check(basename(filename));
         if (!valid) {
-          grunt.log.error(options.error.replace(/{filename}/, filename, 'gi').replace(/{valid}/, options.valid.toString(), 'gi'));
+          grunt.log.error(
+			  options.error
+				  .replace(/{filename}/, filename, 'gi')
+				  .replace(/{valid}/, options.valid.toString(), 'gi')
+		  );
         }
         return valid;
       });


### PR DESCRIPTION
This allows error message configuration.

grunt.initConfig({
  filenames: {
    options: {
      valid: /^[a-z]+.js$/,
      error: 'your file {filename} does not come close to passing {valid}'
    },
    src: ['tasks/*.js']
  }
});
